### PR TITLE
hotfix for release

### DIFF
--- a/examples/src/main/scala/com/github/cloudml/zen/examples/ml/LDADriver.scala
+++ b/examples/src/main/scala/com/github/cloudml/zen/examples/ml/LDADriver.scala
@@ -35,7 +35,7 @@ object LDADriver {
     if (args.length < 9) {
       println("usage: LDADriver <numTopics> <alpha> <beta> <alphaAs> <totalIteration>" +
         " <input path> <output path> <sampleRate> <partition num> " +
-        "{<use DBHStrategy>} {<use kryo serialize>}")
+        "{<LDA Algorithm>} {<use DBHStrategy>} {<use kryo serialize>}")
       System.exit(1)
     }
     val numTopics = args(0).toInt
@@ -60,9 +60,10 @@ object LDADriver {
     assert(partitionNum > 0)
 
     val conf = new SparkConf()
-    val useDBHStrategy: Boolean = if (args.length > 9) args(9).toBoolean else false
+    val LDAAlgorithm: String = if (args.length > 9) args(9).toLowerCase else "default"
+    val useDBHStrategy: Boolean = if (args.length > 10) args(10).toBoolean else false
 
-    if (args.length > 10) {
+    if (args.length > 11) {
       conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       conf.set("spark.kryo.registrator", "com.github.cloudml.zen.ml.clustering.LDAKryoRegistrator")
       GraphXUtils.registerKryoClasses(conf)
@@ -81,8 +82,8 @@ object LDADriver {
     val trainingDocs = readDocsFromTxt(sc, inputDataPath, sampleRate, partitionNum)
     println(s"trainingDocs count: ${trainingDocs.count()}")
 
-    val trainingTime = runTraining(sc, outputRootPath, numTopics,
-      totalIter, alpha, beta, alphaAS, trainingDocs, useDBHStrategy)
+    val trainingTime = runTraining(sc, outputRootPath, numTopics, totalIter, alpha, beta, alphaAS,
+      trainingDocs, LDAAlgorithm, useDBHStrategy)
 
     val appEndedTime = System.currentTimeMillis()
     println(s"Training time consumed: $trainingTime seconds")
@@ -98,13 +99,14 @@ object LDADriver {
     beta: Float,
     alphaAS: Float,
     trainingDocs: RDD[(Long, SV)],
+    LDAAlgorithm: String,
     useDBHStrategy: Boolean): Double = {
     SparkHacker.gcCleaner(15 * 60, 15 * 60, "LDA_gcCleaner")
     val trainingStartedTime = System.currentTimeMillis()
     // val storage =  StorageLevel.DISK_ONLY
     val storage = StorageLevel.MEMORY_AND_DISK
     val termModel = LDA.train(trainingDocs, totalIter, numTopics, alpha, beta, alphaAS,
-      useDBHStrategy, storageLevel = storage)
+      LDAAlgorithm, useDBHStrategy, storageLevel = storage)
     val trainingEndedTime = System.currentTimeMillis()
 
     println("save the model both in doc-term view or term-doc view")

--- a/examples/src/main/scala/com/github/cloudml/zen/examples/ml/LDADriver.scala
+++ b/examples/src/main/scala/com/github/cloudml/zen/examples/ml/LDADriver.scala
@@ -35,7 +35,7 @@ object LDADriver {
     if (args.length < 9) {
       println("usage: LDADriver <numTopics> <alpha> <beta> <alphaAs> <totalIteration>" +
         " <input path> <output path> <sampleRate> <partition num> " +
-        "{<LDA Algorithm>} {<use DBHStrategy>} {<use kryo serialize>}")
+        "{<LDA Algorithm>} {<use DBHStrategy>} {<saveAsSolid>} {<use kryo serialize>}")
       System.exit(1)
     }
     val numTopics = args(0).toInt
@@ -62,8 +62,9 @@ object LDADriver {
     val conf = new SparkConf()
     val LDAAlgorithm: String = if (args.length > 9) args(9).toLowerCase else "default"
     val useDBHStrategy: Boolean = if (args.length > 10) args(10).toBoolean else false
+    val saveSolid: Boolean = if (args.length > 11) args(11).toBoolean else false
 
-    if (args.length > 11) {
+    if (args.length > 12) {
       conf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       conf.set("spark.kryo.registrator", "com.github.cloudml.zen.ml.clustering.LDAKryoRegistrator")
       GraphXUtils.registerKryoClasses(conf)
@@ -83,7 +84,7 @@ object LDADriver {
     println(s"trainingDocs count: ${trainingDocs.count()}")
 
     val trainingTime = runTraining(sc, outputRootPath, numTopics, totalIter, alpha, beta, alphaAS,
-      trainingDocs, LDAAlgorithm, useDBHStrategy)
+      trainingDocs, LDAAlgorithm, useDBHStrategy, saveSolid)
 
     val appEndedTime = System.currentTimeMillis()
     println(s"Training time consumed: $trainingTime seconds")
@@ -100,7 +101,8 @@ object LDADriver {
     alphaAS: Float,
     trainingDocs: RDD[(Long, SV)],
     LDAAlgorithm: String,
-    useDBHStrategy: Boolean): Double = {
+    useDBHStrategy: Boolean,
+    saveSolid: Boolean): Double = {
     SparkHacker.gcCleaner(15 * 60, 15 * 60, "LDA_gcCleaner")
     val trainingStartedTime = System.currentTimeMillis()
     // val storage =  StorageLevel.DISK_ONLY
@@ -109,8 +111,8 @@ object LDADriver {
       LDAAlgorithm, useDBHStrategy, storageLevel = storage)
     val trainingEndedTime = System.currentTimeMillis()
 
-    println("save the model both in doc-term view or term-doc view")
-    termModel.save(sc, outputRootPath, isTransposed = true)
+    println("save the model in term-doc view")
+    termModel.save(sc, outputRootPath, isTransposed = true, saveSolid)
     // docModel.save(sc, outputRootPath + "/doc-topic", isTransposed = false)
 
     // try to delete the checkpoint folder in the HDFS

--- a/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDA.scala
+++ b/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDA.scala
@@ -313,7 +313,7 @@ object LDA {
    * @param alpha      recommend to be (5.0 /numTopics)
    * @param beta       recommend to be in range 0.001 - 0.1
    * @param alphaAS    recommend to be in range 0.01 - 1.0
-   * @param useLightLDA use LightLDA sampling algorithm or not, recommend false for short text
+   * @param LDAAlgorithm which LDA sampling algorithm to use, recommend not lightlda for short text
    * @param useDBHStrategy whether DBH Strategy to re partition by the graph
    * @return DistributedLDAModel
    */
@@ -324,14 +324,18 @@ object LDA {
     alpha: Float = 0.001f,
     beta: Float = 0.01f,
     alphaAS: Float = 0.1f,
-    useLightLDA: Boolean = false,
+    LDAAlgorithm: String = "default",
     useDBHStrategy: Boolean = false,
     storageLevel: StorageLevel = StorageLevel.MEMORY_AND_DISK): DistributedLDAModel = {
     require(totalIter > 0, "totalIter is less than 0")
-    val lda = if (useLightLDA) {
-      new LightLDA(docs, numTopics, alpha, beta, alphaAS, useDBHStrategy, storageLevel)
-    } else {
-      new FastLDA(docs, numTopics, alpha, beta, alphaAS, useDBHStrategy, storageLevel)
+    val lda: LDA = LDAAlgorithm match {
+      case "lightlda" =>
+        println("using LightLDA sampling algorithm.")
+        new LightLDA(docs, numTopics, alpha, beta, alphaAS, useDBHStrategy, storageLevel)
+      case "fastlda" | "default" =>
+        println("using FastLDA sampling algorithm.")
+        new FastLDA(docs, numTopics, alpha, beta, alphaAS, useDBHStrategy, storageLevel)
+      case _ => throw new NoSuchMethodException("No this algorithm or not implemented.")
     }
     lda.runGibbsSampling(totalIter - 1)
     val termModel = lda.saveModel(1)

--- a/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDA.scala
+++ b/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDA.scala
@@ -178,7 +178,7 @@ abstract class LDA private[ml](
         } else {
           l + 1
         }
-      }.asInstanceOf[Count]), c.length)
+      }.toInt), c.length)
       nc
     })
     ttc.persist(storageLevel)

--- a/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDAModel.scala
+++ b/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDAModel.scala
@@ -650,7 +650,7 @@ object LDAModel extends Loader[DistributedLDAModel] {
         val sv = ttc(offset)
         its.tail.foreach { s =>
           val Array(index, value) = s.split(":")
-          sv(index.toInt) = value.asInstanceOf[Count]
+          sv(index.toInt) = value.toInt
         }
         sv.compact()
 
@@ -682,7 +682,7 @@ object LDAModel extends Loader[DistributedLDAModel] {
         val arr = line.split("\t")
         arr.tail.foreach { sub =>
           val Array(index, value) = sub.split(":")
-          sv(index.toInt) = value.asInstanceOf[Count]
+          sv(index.toInt) = value.toInt
         }
         sv.compact()
         (arr.head.toLong, sv)
@@ -711,7 +711,7 @@ object LDAModel extends Loader[DistributedLDAModel] {
         val arr = line.split("\t")
         arr.tail.foreach { sub =>
           val Array(index, value) = sub.split(":")
-          sv(index.toInt) = value.asInstanceOf[Count]
+          sv(index.toInt) = value.toInt
         }
         sv.compact()
         (arr.head.toLong, sv)

--- a/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDAModel.scala
+++ b/ml/src/main/scala/com/github/cloudml/zen/ml/clustering/LDAModel.scala
@@ -461,11 +461,11 @@ class DistributedLDAModel private[ml](
   }
 
   override def save(sc: SparkContext, path: String): Unit = {
-    save(sc, path, isTransposed = false)
+    save(sc, path, isTransposed = false, saveSolid = false)
   }
 
   def save(path: String): Unit = {
-    save(ttc.context, path, isTransposed = false)
+    save(ttc.context, path, isTransposed = false, saveSolid = false)
   }
 
   /**
@@ -477,9 +477,11 @@ class DistributedLDAModel private[ml](
    *                     otherwise:
    *                     topicId \grave{termId}:counter \grave{termId}:counter...,
    *                     in which \grave{termId}= termId + 1
+   * @param saveSolid save as whether one HDFS file or an directory
    */
-  def save(sc: SparkContext, path: String, isTransposed: Boolean): Unit = {
-    LDAModel.SaveLoadV1_0.save(sc, path, ttc, numTopics, numTerms, alpha, beta, alphaAS, isTransposed)
+  def save(sc: SparkContext, path: String, isTransposed: Boolean, saveSolid: Boolean): Unit = {
+    LDAModel.SaveLoadV1_0.save(sc, path, ttc, numTopics, numTerms, alpha, beta, alphaAS,
+      isTransposed, saveSolid)
   }
 
   override protected def formatVersion: String = LDAModel.SaveLoadV1_0.formatVersionV1_0
@@ -748,7 +750,7 @@ object LDAModel extends Loader[DistributedLDAModel] {
       beta: Float,
       alphaAS: Float,
       isTransposed: Boolean,
-      saveSolid: Boolean = true): Unit = {
+      saveSolid: Boolean): Unit = {
       val metadata = compact(render
         (("class" -> classNameV1_0) ~ ("version" -> formatVersionV1_0) ~
           ("alpha" -> alpha) ~ ("beta" -> beta) ~ ("alphaAS" -> alphaAS) ~

--- a/ml/src/main/scala/com/github/cloudml/zen/ml/util/AliasTable.scala
+++ b/ml/src/main/scala/com/github/cloudml/zen/ml/util/AliasTable.scala
@@ -118,7 +118,6 @@ private[zen] object AliasTable {
     }
     while (!hq.isEmpty) {
       val (h, ph) = hq.remove()
-      assert((ph - pMean) / pMean < 1e-4)
       table.l(offset) = h
       table.h(offset) = h
       table.p(offset) = ph
@@ -127,7 +126,6 @@ private[zen] object AliasTable {
 
     while (!lq.isEmpty) {
       val (i, pi) = lq.remove()
-      assert((pMean - pi) / pMean < 1e-4)
       table.l(offset) = i
       table.h(offset) = i
       table.p(offset) = pi

--- a/ml/src/main/scala/com/github/cloudml/zen/ml/util/AliasTable.scala
+++ b/ml/src/main/scala/com/github/cloudml/zen/ml/util/AliasTable.scala
@@ -118,7 +118,7 @@ private[zen] object AliasTable {
     }
     while (!hq.isEmpty) {
       val (h, ph) = hq.remove()
-      assert(ph - pMean < 1e-8)
+      assert((ph - pMean) / pMean < 1e-4)
       table.l(offset) = h
       table.h(offset) = h
       table.p(offset) = ph
@@ -127,7 +127,7 @@ private[zen] object AliasTable {
 
     while (!lq.isEmpty) {
       val (i, pi) = lq.remove()
-      assert(pMean - pi < 1e-8)
+      assert((pMean - pi) / pMean < 1e-4)
       table.l(offset) = i
       table.h(offset) = i
       table.p(offset) = pi

--- a/ml/src/test/scala/com/github/cloudml/zen/ml/clustering/LDASuite.scala
+++ b/ml/src/test/scala/com/github/cloudml/zen/ml/clustering/LDASuite.scala
@@ -60,7 +60,7 @@ class LDASuite extends FunSuite with SharedSparkContext {
     val tempDir = Files.createTempDir()
     tempDir.deleteOnExit()
     val path = tempDir.toURI.toString
-    ldaModel.save(sc, path, isTransposed = true)
+    ldaModel.save(sc, path, isTransposed = true, saveSolid = true)
     val sameModel = LDAModel.load(sc, path)
     assert(sameModel.toLocalLDAModel().ttc === ldaModel.toLocalLDAModel().ttc)
     assert(sameModel.alpha === ldaModel.alpha)


### PR DESCRIPTION
1. fix assert error when generating AliasTable
2. fix type conversion function (Double => T, T => Double)
3. add two cmd option: <LDA Algorithm> <saveAsSolid>.  <LDA Algorithm> controls which LDA sampling algorithm to use (valid value is fastlda/lightlda/default, case-insensitive). <saveAsSolid> controls whether save model as one file or a directory (valid value is true/false).