### PR TITLE
Increase iteration count for ldaModel.inference testing

### DIFF
--- a/ml/src/test/scala/com/github/cloudml/zen/ml/clustering/LDASuite.scala
+++ b/ml/src/test/scala/com/github/cloudml/zen/ml/clustering/LDASuite.scala
@@ -111,8 +111,8 @@ class LDASuite extends FunSuite with SharedSparkContext {
 
     val ldaModel = lda.toLDAModel.toLocalLDAModel
     data.collect().foreach { case (_, sv) =>
-      val a = ldaModel.inference(sv)
-      val b = ldaModel.inference(sv)
+      val a = ldaModel.inference(sv, 100, 80)
+      val b = ldaModel.inference(sv, 100, 80)
       val sim: Double = euclideanDistance(a, b)
       assert(sim < 0.1)
     }
@@ -145,8 +145,8 @@ class LDASuite extends FunSuite with SharedSparkContext {
 
     val ldaModel = lda.toLDAModel.toLocalLDAModel
     data.collect().foreach { case (_, sv) =>
-      val a = ldaModel.inference(sv)
-      val b = ldaModel.inference(sv)
+      val a = ldaModel.inference(sv, 100, 80)
+      val b = ldaModel.inference(sv, 100, 80)
       val sim: Double = euclideanDistance(a, b)
       assert(sim < 0.1)
     }
@@ -179,8 +179,8 @@ class LDASuite extends FunSuite with SharedSparkContext {
 
     val ldaModel = lda.toLDAModel.toLocalLDAModel
     data.collect().foreach { case (_, sv) =>
-      val a = ldaModel.inference(sv)
-      val b = ldaModel.inference(sv)
+      val a = ldaModel.inference(sv, 100, 80)
+      val b = ldaModel.inference(sv, 100, 80)
       val sim: Double = euclideanDistance(a, b)
       assert(sim < 0.1)
     }
@@ -213,8 +213,8 @@ class LDASuite extends FunSuite with SharedSparkContext {
 
     val ldaModel = lda.toLDAModel.toLocalLDAModel
     data.collect().foreach { case (_, sv) =>
-      val a = ldaModel.inference(sv)
-      val b = ldaModel.inference(sv)
+      val a = ldaModel.inference(sv, 100, 80)
+      val b = ldaModel.inference(sv, 100, 80)
       val sim: Double = euclideanDistance(a, b)
       assert(sim < 0.1)
     }


### PR DESCRIPTION
Hi,
It seems that these distance computation functions (i.e., `euclideanDistance(a, b)`) frequently return the euclidean distance upper than `0.1`.
I'm not sure this is the best solution but I think it's better than to set the larger value (e.g., use `0.3` instead of `0.1`) for similarity testing.

Cheers,